### PR TITLE
Add volto-fullcalendar-block

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Various addons that can't fit in a specific category:
 - [volto-newsblock](https://github.com/rohberg/volto-newsblock) - Volto block with selected news items
 - [volto-authomatic](https://github.com/collective/volto-authomatic) - Social login for Plone ( Using [pas.plugins.authomatic](https://github.com/collective/pas.plugins.authomatic))
 - [volto-leaflet-block](https://github.com/adeweb-be/volto-leaflet-block) - A Leaflet map block for Volto
+- [volto-fullcalendar-block](https://github.com/mbarde/volto-fullcalendar-block) - A block for adding a [FullCalendar](https://fullcalendar.io/) to display events from an ics/iCal file
 
 
 ### Rich text editing


### PR DESCRIPTION
Not yet complete (missing configuration options) but might be a good starting point for own implementations.