### PR TITLE
Remove rietveldSchroderhuis.nl

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,6 @@ The following websites have been built with Volto. You can find their complete s
 - [volto-centraalmuseum-theme](https://github.com/intk/volto-centraalmuseum-theme) - Volto project for the [Centraal Museum & Rietveld](https://www.centraalmuseum.nl/nl) made for [INTK](https://www.intk.com/en).
 - [volto-eea-design-system](https://github.com/eea/volto-eea-design-system) - EEA Design System Plone 6 Kit Volto project for [European Environment Agency web sites](https://eea.github.io/volto-eea-design-system/)
 - [volto-eea-kitkat](https://github.com/eea/volto-eea-kitkat) - A known good set of Volto add-ons to be used within all EEA projects and beyond, made for [European Environment Agency](https://www.eea.europa.eu/en)
-- [volto-rietveldschroderhuis-theme](https://github.com/intk/volto-rietveldschroderhuis-theme) - Volto project for the [Rietveld Schröder House](https://www.rietveldschroderhuis.nl/en) made for [INTK](https://www.intk.com/en).
 - [volto-zeeuwsmuseum-theme](https://github.com/intk/volto-zeeuwsmuseum-theme) - Volto project for the [Zeeuws Museum](https://www.zeeuwsmuseum.nl/en) made for [INTK](https://www.intk.com/en).
 
 


### PR DESCRIPTION
The site https://www.rietveldschroderhuis.nl/ has been down for at least 3 days, it causes a CI job to fail in Volto, the owners have not responded, and they removed the site from their monitoring repo. Let's give them one more day to respond, then merge if they do not.

See https://github.com/plone/volto/pull/6604#issuecomment-2601494573

@cihanandac @andreesg @ruibeep @simonbrunel @macagua 